### PR TITLE
Bqdev

### DIFF
--- a/SECRETS/codesEXAMPLE.yaml
+++ b/SECRETS/codesEXAMPLE.yaml
@@ -4,3 +4,4 @@ inferkey: # Ultralytics HUB API key
 botID: # Discord bot ID number
 ownerID: # Owner ID for the bot, allows running dev commands
 devGuild: # Owner/developer Guild ID
+devCh: # Developer channel for notification messages

--- a/cfg/commands.yaml
+++ b/cfg/commands.yaml
@@ -201,6 +201,13 @@ Global:
     content: null
     parameters: null # List of sub-section choices
 
+  docs_hub: 
+    name: Docs - HUB
+    slash_cmd: /docs_hub
+    description: Reference Ultralytics HUB Documentation.
+    content: null
+    parameters: null # List of sub-section choices
+
   # TEMPLATE: 
   #   name: 
   #   slash_cmd: 

--- a/src/UltralyticsBot/__init__.py
+++ b/src/UltralyticsBot/__init__.py
@@ -21,6 +21,7 @@ BOT_ID = SECRETS['botID']
 HUB_KEY = SECRETS['inferkey']
 OWNER_ID = SECRETS['ownerID']
 DEV_GUILD = SECRETS['devGuild']
+DEV_CH = SECRETS['devCh']
 
 # Commands config
 CMDS = yaml.safe_load((PROJ_ROOT / 'cfg/commands.yaml').read_text('utf-8'))

--- a/src/UltralyticsBot/cmds/client.py
+++ b/src/UltralyticsBot/cmds/client.py
@@ -5,24 +5,46 @@ Date: 2023-10-29
 
 Requires: discord.py
 """
+import datetime
 
 import discord
 from discord import app_commands
+from discord.ext import tasks
 
-from UltralyticsBot import CMDS
+from UltralyticsBot import CMDS, DEV_CH
 from UltralyticsBot.utils.logging import Loggr
+from UltralyticsBot.utils.docs_data import docs_choices, load_docs_cache
+
+RUN_AT = datetime.time(hour=0, minute=0, second=0, tzinfo=datetime.timezone.utc) # time to refresh repo and docs
 
 class MyClient(discord.Client):
     """Class for Discord application/bot with slash-commands, requires message content intents"""
     def __init__(self, *, intents:discord.Intents):
         super().__init__(intents=intents)
         self.tree = app_commands.CommandTree(self)
+        self.docs_choices, self.docs_embeds = load_docs_cache()
         self.cmd_pop()
     
     async def setup(self):
         """Sync commands, could take upto an hour to show up when bot is in lots of servers"""
         Loggr.info(f"Intitating client sync.")
         await self.tree.sync()
+    
+    async def setup_hook(self) -> None:
+        # return await super().setup_hook()
+        self.docs_update.start()
+    
+    @tasks.loop(time=RUN_AT)
+    async def docs_update(self):
+        """Task loop to update Documentation commands."""
+        notice_ch = self.get_channel(DEV_CH)
+        Loggr.info(f"Running scheduled docs command.")
+        self.docs_choices, self.docs_embeds = docs_choices()
+        await notice_ch.send(content=f"Docs update task completed.")
+
+    @docs_update.before_loop
+    async def before_my_task(self):
+        await self.wait_until_ready()
     
     def cmd_pop(self, cmds:dict=CMDS):
         """Populate client with commands from YAML file."""


### PR DESCRIPTION
- fix docs repo fetch command, now uses `pull`
- corrected repo fetch `cwd` for command
- new task loop added for daily update of repo documentation at midnight UTC
- documentation `app_command.Choice` and `discord.Embed` objects now stored with `MyClient` class
- documentation caches locally and daily updates are made to `client` for `/docs` commands no older than 24 hours
- added `docs_hub` command
- added brand formatting function for `discord.Embed` text
- fixed command sync for specific servers and updated message formatting